### PR TITLE
fix: parse oneoff dirs remove trailing fs

### DIFF
--- a/lua/telescope/_extensions/whaler/main.lua
+++ b/lua/telescope/_extensions/whaler/main.lua
@@ -97,8 +97,9 @@ M.dirs = function()
     local subdirs = M.get_entries(hd) or {}
 
     -- Merge the oneoff directories
-    for _, oneoff in ipairs(oneoff_directories)do
-        subdirs[oneoff] = oneoff
+    for _, oneoff in ipairs(oneoff_directories) do
+        local parsed_oneoff = _utils.parse_directory(oneoff) -- Remove any / at the end.
+        subdirs[parsed_oneoff] = parsed_oneoff
     end
 
     return subdirs


### PR DESCRIPTION
Directories should be parsed so there are no duplicates.
Pull request: https://github.com/SalOrak/whaler.nvim/pull/8